### PR TITLE
Removing 'flag on'

### DIFF
--- a/apps/flag on/app.yml
+++ b/apps/flag on/app.yml
@@ -1,7 +1,0 @@
-version: 43.0.9
-pageUuid: 55a1ef42-7194-11ed-bbb3-779850a7e1fa
-appTemplate:
-  queryStatusVisibility: false
-  rootScreen: null
-  version: 2.103.3
-  markdownLinkBehavior: auto


### PR DESCRIPTION
### Removing 'flag on'

This PR will remove the application from the Retool Source Control repository.

Preview application here: http://localhost:3000/apps/flag%20on
